### PR TITLE
テストの見通しよくするために定数→voの型変換が行われる箇所は不要な変換処理削除

### DIFF
--- a/departures-time-api/handler/request/nearby_stations_test.go
+++ b/departures-time-api/handler/request/nearby_stations_test.go
@@ -5,28 +5,11 @@ import (
 	"net/http"
 	"testing"
 
-	"github.com/haton14/departures-time/departures-time-api/domain/vo"
 	"github.com/haton14/departures-time/departures-time-api/handler/request"
 	"github.com/stretchr/testify/assert"
 )
 
 func TestNewNearbyStationsGet(t *testing.T) {
-	lo, err := vo.NewLongitude(139.7274062)
-	if err != nil {
-		t.Fatal(err)
-	}
-	la, err := vo.NewLatitude(35.5920096)
-	if err != nil {
-		t.Fatal(err)
-	}
-	distance500, err := vo.NewDistance(500)
-	if err != nil {
-		t.Fatal(err)
-	}
-	distanceMaxInt, err := vo.NewDistance(math.MaxInt)
-	if err != nil {
-		t.Fatal(err)
-	}
 
 	testsOK := map[string]struct {
 		query    map[string]string
@@ -39,9 +22,9 @@ func TestNewNearbyStationsGet(t *testing.T) {
 				"distance":  "500",
 			},
 			expected: &request.NearbyStationsGet{
-				Longitude: *lo,
-				Latitude:  *la,
-				Distance:  *distance500,
+				Longitude: 139.7274062,
+				Latitude:  35.5920096,
+				Distance:  500,
 			},
 		}, "[正常]:経度139.7274062,緯度35.5920096,距離指定なし": {
 			query: map[string]string{
@@ -49,9 +32,9 @@ func TestNewNearbyStationsGet(t *testing.T) {
 				"latitude":  "35.5920096",
 			},
 			expected: &request.NearbyStationsGet{
-				Longitude: *lo,
-				Latitude:  *la,
-				Distance:  *distanceMaxInt,
+				Longitude: 139.7274062,
+				Latitude:  35.5920096,
+				Distance:  math.MaxInt,
 			},
 		},
 	}

--- a/departures-time-api/repository/nearby_station_detail_test.go
+++ b/departures-time-api/repository/nearby_station_detail_test.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/golang/mock/gomock"
 	"github.com/haton14/departures-time/departures-time-api/domain/model"
-	"github.com/haton14/departures-time/departures-time-api/domain/vo"
 	"github.com/haton14/departures-time/departures-time-api/external"
 	mock_external "github.com/haton14/departures-time/departures-time-api/external/mock"
 	"github.com/haton14/departures-time/departures-time-api/repository"
@@ -14,27 +13,7 @@ import (
 )
 
 func TestNearbyStationDetailGetByNearbyStation(t *testing.T) {
-	toLo := func(v float64) vo.Longitude {
-		l, err := vo.NewLongitude(v)
-		if err != nil {
-			t.Fatal(err)
-		}
-		return *l
-	}
-	toLa := func(v float64) vo.Latitude {
-		l, err := vo.NewLatitude(v)
-		if err != nil {
-			t.Fatal(err)
-		}
-		return *l
-	}
-	toName := func(v string) vo.StationName {
-		sn, err := vo.NewStationName(v)
-		if err != nil {
-			t.Fatal(err)
-		}
-		return *sn
-	}
+
 	mockData := []external.ExspertDTO{
 		{
 			Station: external.ExspertStation{
@@ -108,15 +87,15 @@ func TestNearbyStationDetailGetByNearbyStation(t *testing.T) {
 	}{
 		"[正常]期待通りのデータが取れる": {
 			arg: model.NearbyStation{
-				Name:      toName("大森"),
-				Longitude: toLo(139.728079),
-				Latitude:  toLa(35.588903),
+				Name:      "大森",
+				Longitude: 139.728079,
+				Latitude:  35.588903,
 			},
 			expected: &model.NearbyStation{
 				Code:      "22566",
-				Name:      toName("大森(東京都)"),
-				Longitude: toLo(139.731138),
-				Latitude:  toLa(35.585139),
+				Name:      "大森(東京都)",
+				Longitude: 139.731138,
+				Latitude:  35.585139,
 			},
 		},
 	}
@@ -210,9 +189,9 @@ func TestNearbyStationDetailGetByNearbyStation(t *testing.T) {
 	}
 
 	ngArg := model.NearbyStation{
-		Name:      toName("大森"),
-		Longitude: toLo(139.728079),
-		Latitude:  toLa(35.588903),
+		Name:      "大森",
+		Longitude: 139.728079,
+		Latitude:  35.588903,
 	}
 
 	for name, tt := range testsNG {

--- a/departures-time-api/repository/nearby_stations_test.go
+++ b/departures-time-api/repository/nearby_stations_test.go
@@ -14,34 +14,7 @@ import (
 )
 
 func TestNearbyStationsGetByLongitudeAndLatitudeAndDistance(t *testing.T) {
-	toLo := func(v float64) vo.Longitude {
-		l, err := vo.NewLongitude(v)
-		if err != nil {
-			t.Fatal(err)
-		}
-		return *l
-	}
-	toLa := func(v float64) vo.Latitude {
-		l, err := vo.NewLatitude(v)
-		if err != nil {
-			t.Fatal(err)
-		}
-		return *l
-	}
-	toName := func(v string) vo.StationName {
-		sn, err := vo.NewStationName(v)
-		if err != nil {
-			t.Fatal(err)
-		}
-		return *sn
-	}
-	toDistance := func(v int) vo.Distance {
-		d, err := vo.NewDistance(v)
-		if err != nil {
-			t.Fatal(err)
-		}
-		return *d
-	}
+
 	mockData := []external.NeaRestApiDTO{
 		{StationName: "大森", Location: []float64{139.728079, 35.588903}, Distance: 351},
 		{StationName: "大森海岸", Location: []float64{39.73544, 35.587576}, Distance: 879},
@@ -82,24 +55,24 @@ func TestNearbyStationsGetByLongitudeAndLatitudeAndDistance(t *testing.T) {
 		expected []model.NearbyStation
 	}{
 		"[正常]:期待通りデータが取れる 500m": {
-			arg: toDistance(500),
+			arg: 500,
 			expected: []model.NearbyStation{
-				{Name: toName("大森"), Longitude: toLo(139.728079), Latitude: toLa(35.588903), Distance: toDistance(351)},
+				{Name: "大森", Longitude: 139.728079, Latitude: 35.588903, Distance: 351},
 			},
 		},
 		"[正常]:期待通りデータが取れる 2000m": {
-			arg: toDistance(2000),
+			arg: 2000,
 			expected: []model.NearbyStation{
-				{Name: toName("大森"), Longitude: toLo(139.728079), Latitude: toLa(35.588903), Distance: toDistance(351)},
-				{Name: toName("大森海岸"), Longitude: toLo(39.73544), Latitude: toLa(35.587576), Distance: toDistance(879)},
-				{Name: toName("西大井"), Longitude: toLo(39.721729), Latitude: toLa(35.601616), Distance: toDistance(1186)},
-				{Name: toName("立会川"), Longitude: toLo(39.738886), Latitude: toLa(35.598489), Distance: toDistance(1265)},
-				{Name: toName("馬込"), Longitude: toLo(39.711772), Latitude: toLa(35.596435), Distance: toDistance(1499)},
-				{Name: toName("平和島"), Longitude: toLo(39.73491), Latitude: toLa(35.57868), Distance: toDistance(1632)},
-				{Name: toName("大井町"), Longitude: toLo(39.73485), Latitude: toLa(35.606257), Distance: toDistance(1723)},
-				{Name: toName("大井競馬場前"), Longitude: toLo(39.74708), Latitude: toLa(35.595006), Distance: toDistance(1812)},
-				{Name: toName("下神明"), Longitude: toLo(39.726256), Latitude: toLa(35.608704), Distance: toDistance(1861)},
-				{Name: toName("鮫洲"), Longitude: toLo(39.742227), Latitude: toLa(35.604977), Distance: toDistance(1971)},
+				{Name: "大森", Longitude: 139.728079, Latitude: 35.588903, Distance: 351},
+				{Name: "大森海岸", Longitude: 39.73544, Latitude: 35.587576, Distance: 879},
+				{Name: "西大井", Longitude: 39.721729, Latitude: 35.601616, Distance: 1186},
+				{Name: "立会川", Longitude: 39.738886, Latitude: 35.598489, Distance: 1265},
+				{Name: "馬込", Longitude: 39.711772, Latitude: 35.596435, Distance: 1499},
+				{Name: "平和島", Longitude: 39.73491, Latitude: 35.57868, Distance: 1632},
+				{Name: "大井町", Longitude: 39.73485, Latitude: 35.606257, Distance: 1723},
+				{Name: "大井競馬場前", Longitude: 39.74708, Latitude: 35.595006, Distance: 1812},
+				{Name: "下神明", Longitude: 39.726256, Latitude: 35.608704, Distance: 1861},
+				{Name: "鮫洲", Longitude: 39.742227, Latitude: 35.604977, Distance: 1971},
 			},
 		},
 	}
@@ -143,7 +116,7 @@ func TestNearbyStationsGetByLongitudeAndLatitudeAndDistance(t *testing.T) {
 				Return(tt.mockData, nil)
 
 			r := repository.NewNearbyStations(neaRestApi)
-			actual, err := r.GetByLongitudeAndLatitudeAndDistance(*lo, *la, toDistance(500))
+			actual, err := r.GetByLongitudeAndLatitudeAndDistance(*lo, *la, 500)
 			assert.Nil(t, actual)
 			assert.Error(t, err)
 		})
@@ -155,7 +128,7 @@ func TestNearbyStationsGetByLongitudeAndLatitudeAndDistance(t *testing.T) {
 			GetNearbyStations(*lo, *la).
 			Return(nil, errors.New("other error"))
 		r := repository.NewNearbyStations(neaRestApi)
-		actual, err := r.GetByLongitudeAndLatitudeAndDistance(*lo, *la, toDistance(500))
+		actual, err := r.GetByLongitudeAndLatitudeAndDistance(*lo, *la, 500)
 		assert.Nil(t, actual)
 		assert.Error(t, err)
 	})

--- a/departures-time-api/usecase/nearby_stations_test.go
+++ b/departures-time-api/usecase/nearby_stations_test.go
@@ -43,7 +43,7 @@ func TestNearbyStationsGetByCoordinateAndDistance(t *testing.T) {
 	}
 
 	mockStations := []model.NearbyStation{
-		{Name: toName("大森"), Longitude: toLo(139.728079), Latitude: toLa(35.588903), Distance: toDistance(351)},
+		{Name: "大森", Longitude: 139.728079, Latitude: 35.588903, Distance: 351},
 	}
 
 	ctrl := gomock.NewController(t)
@@ -69,16 +69,16 @@ func TestNearbyStationsGetByCoordinateAndDistance(t *testing.T) {
 			After(f)
 
 		u := usecase.NewNearbyStations(nearbyStations, nearbyStationDetail)
-		actual, err := u.GetByCoordinateAndDistance(toLo(139.728079), toLa(35.588903), toDistance(500))
+		actual, err := u.GetByCoordinateAndDistance(139.728079, 35.588903, 500)
 		assert.NoError(t, err)
 
 		expected := []model.NearbyStation{
 			{
 				Code:      "22566",
-				Name:      toName("大森(東京都)"),
-				Longitude: toLo(139.728079),
-				Latitude:  toLa(35.588903),
-				Distance:  toDistance(351),
+				Name:      "大森(東京都)",
+				Longitude: 139.728079,
+				Latitude: 35.588903,
+				Distance:  351,
 			},
 		}
 		assert.Equal(t, expected, actual)
@@ -91,7 +91,7 @@ func TestNearbyStationsGetByCoordinateAndDistance(t *testing.T) {
 			Return(nil, errors.New("other error"))
 
 		u := usecase.NewNearbyStations(nearbyStations, nearbyStationDetail)
-		actual, err := u.GetByCoordinateAndDistance(toLo(139.728079), toLa(35.588903), toDistance(500))
+		actual, err := u.GetByCoordinateAndDistance(139.728079, 35.588903, 500)
 		assert.Error(t, err)
 		assert.Nil(t, actual)
 	})
@@ -109,7 +109,7 @@ func TestNearbyStationsGetByCoordinateAndDistance(t *testing.T) {
 			After(f)
 
 		u := usecase.NewNearbyStations(nearbyStations, nearbyStationDetail)
-		actual, err := u.GetByCoordinateAndDistance(toLo(139.728079), toLa(35.588903), toDistance(500))
+		actual, err := u.GetByCoordinateAndDistance(139.728079, 35.588903, 500)
 		assert.Error(t, err)
 		assert.Nil(t, actual)
 	})


### PR DESCRIPTION
mockの期待する引数指定はinterface型なので、定数⇨voの型変換が行われないが
構造体の要素がvoの場合は定数指定すればキャストされるので、テストの期待値もわざわざキャストする必要はない。